### PR TITLE
feat: instrument opamp request cycle

### DIFF
--- a/opamp-client/src/http/client.rs
+++ b/opamp-client/src/http/client.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{http_client::HttpClient, managed_client::Notifier, sender::HttpSender};
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info_span, trace, trace_span};
 
 /// `UnManagedClient` is a trait for clients that do not manage their own polling.
 pub trait UnManagedClient: Client {
@@ -62,7 +62,7 @@ where
         let instance_uid = start_settings.instance_uid.to_string();
 
         Ok(Self {
-            sender: HttpSender::new(http_client),
+            sender: HttpSender::new(http_client, start_settings.instance_uid.clone()),
             callbacks,
             message: Arc::new(RwLock::new(NextMessage::new(AgentToServer {
                 instance_uid: start_settings.instance_uid.into(),
@@ -103,7 +103,7 @@ where
             .write()
             .map_err(|_| ClientError::PoisonError)?
             .pop();
-        trace!(instance_uid = self.instance_uid, "Send payload: {:?}", msg);
+        trace!("Send payload: {:?}", msg);
         let server_to_agent = self.sender.send(msg).map_err(|e| {
             let err_msg = e.to_string();
             self.callbacks.on_connect_failed(e.into());
@@ -113,12 +113,9 @@ where
         // We consider it connected if we receive 2XX status from the Server.
         self.callbacks.on_connect();
 
-        trace!(
-            instance_uid = self.instance_uid,
-            "Received payload: {:?}",
-            server_to_agent
-        );
+        trace!("Received payload: {:?}", server_to_agent);
 
+        let _span = info_span!("process_message").entered();
         if let ProcessResult::NeedsResend = crate::common::message_processor::process_message(
             server_to_agent,
             &self.callbacks,


### PR DESCRIPTION
This PR adds spans to OpAMP request cycle. Each iteration will be a separated span. Logs inside the span will contain the `instance_uid`.

If any error happens during the send / receive / process message, the error should be attached to the span.

Logs in trace mode:
```
2025-03-21T16:17:52 DEBUG opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}:: sending requested AgentToServer message
2025-03-21T16:17:52 TRACE opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}:: Send payload: AgentToServer { instance_uid: [1, 149, 180, 75, 212, 58, 123, 242, 171, 47, 90, 249, 56, 80, 39, 193], sequence_num: 3, agent_description: None, capabilities: 6151, health: Some(ComponentHealth { healthy: true, start_time_unix_nano: 1742570266435763000, last_error: "", status: "", status_time_unix_nano: 1742570266452055000, component_health_map: {} }), effective_config: Some(EffectiveConfig { config_map: Some(AgentConfigMap { config_map: {"": AgentConfigFile { body: "agents: {}
", content_type: "text/yaml" }} }) }), remote_config_status: None, package_statuses: None, agent_disconnect: None, flags: 0, connection_settings_request: None, custom_capabilities: None, custom_message: None }
2025-03-21T16:17:52 TRACE opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}:: Received payload: ServerToAgent { instance_uid: [1, 149, 180, 75, 212, 58, 123, 242, 171, 47, 90, 249, 56, 80, 39, 193], error_response: None, remote_config: None, connection_settings: None, packages_available: None, flags: 0, capabilities: 7, agent_identification: None, command: None, custom_capabilities: None, custom_message: None }
2025-03-21T16:17:52 TRACE opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}::process_message: opamp message received: MessageData { remote_config: None, own_metrics: None, own_traces: None, own_logs: None, other_connection_settings: {}, agent_identification: None, custom_capabilities: None, custom_message: None }, agent_id: agent-control
2025-03-21T16:17:52 TRACE opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}::process_message: Empty OpAMP message received, agent_id: agent-control
2025-03-21T16:17:52 TRACE opamp server is reachable
2025-03-21T16:18:11 TRACE no agents to clean since last execution
2025-03-21T16:18:22 DEBUG opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}:: sending scheduled status report AgentToServer message
2025-03-21T16:18:22 TRACE opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}:: Send payload: AgentToServer { instance_uid: [1, 149, 180, 75, 212, 58, 123, 242, 171, 47, 90, 249, 56, 80, 39, 193], sequence_num: 4, agent_description: None, capabilities: 6151, health: None, effective_config: None, remote_config_status: None, package_statuses: None, agent_disconnect: None, flags: 0, connection_settings_request: None, custom_capabilities: None, custom_message: None }
2025-03-21T16:18:22 TRACE opamp{instance_uid: 0195B44BD43A7BF2AB2F5AF9385027C1}:: Received payload: ServerToAgent { instance_uid: [1, 149, 180, 75, 212, 58, 123, 242, 171, 47, 90, 249, 56, 80, 39, 193], error_response: None, remote_config: None, connection_settings: None, packages_available: None, flags: 0, capabilities: 7, agent_identification: None, command: None, custom_capabilities: None, custom_message: None }
```
<img width="2108" alt="Screenshot 2025-03-21 at 17 42 32" src="https://github.com/user-attachments/assets/b56bb9b1-7f20-4108-87ed-8ffb239b5a89" />


<img width="2338" alt="Screenshot 2025-03-21 at 17 43 03" src="https://github.com/user-attachments/assets/20c242b9-4269-4300-a4c6-823290b4e31e" />
