### PR TITLE
chore: update string interpolation

### DIFF
--- a/proto/src/impls.rs
+++ b/proto/src/impls.rs
@@ -85,14 +85,14 @@ impl Debug for AnyValue {
         match &self.value {
             Some(Value::BytesValue(value)) => {
                 let data = String::from_utf8(value.clone()).unwrap_or(format!("{:?}", &value));
-                write!(f, "{:?}", data)
+                write!(f, "{data:?}")
             }
-            Some(Value::StringValue(value)) => write!(f, "{:?}", value),
-            Some(Value::IntValue(value)) => write!(f, "{:?}", value),
-            Some(Value::DoubleValue(value)) => write!(f, "{:?}", value),
-            Some(Value::BoolValue(value)) => write!(f, "{:?}", value),
-            Some(Value::ArrayValue(value)) => write!(f, "{:?}", value),
-            Some(Value::KvlistValue(value)) => write!(f, "{:?}", value),
+            Some(Value::StringValue(value)) => write!(f, "{value:?}"),
+            Some(Value::IntValue(value)) => write!(f, "{value:?}"),
+            Some(Value::DoubleValue(value)) => write!(f, "{value:?}"),
+            Some(Value::BoolValue(value)) => write!(f, "{value:?}"),
+            Some(Value::ArrayValue(value)) => write!(f, "{value:?}"),
+            Some(Value::KvlistValue(value)) => write!(f, "{value:?}"),
             None => write!(f, "None"),
         }
     }
@@ -167,8 +167,8 @@ mod tests {
             ..Default::default()
         };
 
-        eprintln!("{:?}", sample_message);
+        eprintln!("{sample_message:?}");
 
-        assert_eq!(format!("{:?}", sample_message), expected_string);
+        assert_eq!(format!("{sample_message:?}"), expected_string);
     }
 }


### PR DESCRIPTION
Passed cargo clippy --fix as of Rust 1.88 and fixed some potential warnings that will break our CI/CD once we bump the Rust version of the project.