### PR TITLE
chore(renovate): enable lockFileMaintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,7 @@
   prConcurrentLimit: 0,
   printConfig: true,
   prHourlyLimit: 0,
+  lockFileMaintenance: { enabled: true }, // Update transitive dependencies by keeping lockfile updated
   packageRules: [
     {
       matchManagers: [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,9 +2110,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Enables `lockFileMaintenance` in renovate's config in order to keep dependencies updated.