### PR TITLE
fix: fix docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Read Rust version from Cargo.toml
         id: rust-version
         run: |
-          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]\"")
+          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]")
           echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
       - name: Install Rust ${{ env.RUST_VERSION }}
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -56,4 +56,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5 # or specific "vX.X.X" version tag for this action
-

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,10 +15,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@eb231821b5a5669d0337b42f5623d77e0bcf01b7 # 1.85.0
+      - name: Read Rust version from Cargo.toml
+        id: rust-version
+        run: |
+          RUST_VERSION=$(grep "rust-version" Cargo.toml | cut -d "=" -f2 | tr -d "[:space:]\"")
+          echo "RUST_VERSION=${RUST_VERSION}" >> $GITHUB_ENV
+      - name: Install Rust ${{ env.RUST_VERSION }}
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_VERSION }}
       - name: Clean docs folder
         run: cargo clean --doc
       - name: Build docs


### PR DESCRIPTION
The docs workflow didn't have the rust version aligned and it was failing

<details>
<summary>Failure example</summary>

https://github.com/newrelic/newrelic-opamp-rs/actions/runs/26214482977/job/77133254330

```
Run cargo doc --no-deps
    Updating crates.io index
 Downloading crates ...
  Downloaded crossbeam v0.8.4
  Downloaded anyhow v1.0.102
  Downloaded adler32 v1.2.0
  Downloaded cfg-if v1.0.4
  Downloaded allocator-api2 v0.2.21
  Downloaded bitflags v2.11.1
  Downloaded errno v0.3.14
  Downloaded itoa v1.0.18
  Downloaded libflate_lz77 v2.3.0
  Downloaded multimap v0.10.1
  Downloaded heck v0.5.0
  Downloaded equivalent v1.0.2
  Downloaded prost-derive v0.14.3
  Downloaded crc32fast v1.5.0
  Downloaded crossbeam-queue v0.3.12
  Downloaded rand_core v0.10.1
  Downloaded foldhash v0.2.0
  Downloaded fixedbitset v0.5.7
  Downloaded thiserror v2.0.18
  Downloaded tracing-attributes v0.1.31
  Downloaded foldhash v0.1.5
  Downloaded crossbeam-utils v0.8.21
  Downloaded unicode-ident v1.0.24
  Downloaded tracing-core v0.1.36
  Downloaded serde_derive v1.0.228
  Downloaded uuid v1.23.1
  Downloaded once_cell v1.21.4
  Downloaded serde v1.0.228
  Downloaded http v1.4.0
  Downloaded indexmap v2.14.0
  Downloaded regex v1.12.3
  Downloaded itertools v0.14.0
  Downloaded hashbrown v0.17.1
  Downloaded hashbrown v0.16.1
  Downloaded hashbrown v0.15.5
  Downloaded aho-corasick v1.1.4
  Downloaded memchr v2.8.0
  Downloaded crossbeam-channel v0.5.15
  Downloaded proc-macro2 v1.0.106
  Downloaded syn v2.0.117
  Downloaded prettyplease v0.2.37
  Downloaded rle-decode-fast v1.0.3
  Downloaded prost-build v0.14.3
  Downloaded regex-syntax v0.8.10
  Downloaded getrandom v0.4.2
  Downloaded tracing v0.1.44
  Downloaded rustix v1.1.4
  Downloaded thiserror-impl v2.0.18
  Downloaded serde_core v1.0.228
  Downloaded prost-types v0.14.3
  Downloaded log v0.4.29
  Downloaded libflate v2.3.0
  Downloaded crossbeam-epoch v0.9.18
  Downloaded bytes v1.11.1
  Downloaded tempfile v3.27.0
  Downloaded prost v0.14.3
  Downloaded no_std_io2 v0.9.4
  Downloaded crossbeam-deque v0.8.6
  Downloaded regex-automata v0.4.14
  Downloaded dary_heap v0.3.9
  Downloaded fastrand v2.4.1
  Downloaded either v1.15.0
  Downloaded libc v0.2.186
  Downloaded quote v1.0.45
  Downloaded petgraph v0.8.3
  Downloaded pin-project-lite v0.2.17
  Downloaded linux-raw-sys v0.12.1
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.45
   Compiling unicode-ident v1.0.24
   Compiling libc v0.2.186
   Compiling anyhow v1.0.102
   Compiling either v1.15.0
   Compiling getrandom v0.4.2
   Compiling itertools v0.14.0
   Compiling rustix v1.1.4
   Compiling syn v2.0.117
   Compiling prettyplease v0.2.37
   Compiling regex-syntax v0.8.10
   Compiling cfg-if v1.0.4
   Compiling foldhash v0.1.5
   Compiling crossbeam-utils v0.8.21
   Compiling bytes v1.11.1
   Compiling hashbrown v0.17.1
   Compiling equivalent v1.0.2
   Compiling bitflags v2.11.1
   Compiling linux-raw-sys v0.12.1
   Compiling indexmap v2.14.0
   Compiling regex-automata v0.4.14
   Compiling hashbrown v0.15.5
   Compiling fixedbitset v0.5.7
   Compiling fastrand v2.4.1
   Compiling once_cell v1.21.4
   Compiling tempfile v3.27.0
   Compiling regex v1.12.3
   Compiling petgraph v0.8.3
   Compiling log v0.4.29
   Compiling multimap v0.10.1
   Compiling heck v0.5.0
   Compiling crc32fast v1.5.0
   Compiling prost-derive v0.14.3
    Checking memchr v2.8.0
    Checking foldhash v0.2.0
    Checking allocator-api2 v0.2.21
    Checking no_std_io2 v0.9.4
    Checking hashbrown v0.16.1
    Checking crossbeam-epoch v0.9.18
    Checking rle-decode-fast v1.0.3
   Compiling thiserror v2.0.18
    Checking libflate_lz77 v2.3.0
    Checking tracing-core v0.1.36
    Checking crossbeam-deque v0.8.6
   Compiling thiserror-impl v2.0.18
   Compiling tracing-attributes v0.1.31
    Checking crossbeam-channel v0.5.15
   Compiling prost v0.14.3
   Compiling prost-types v0.14.3
    Checking crossbeam-queue v0.3.12
    Checking pin-project-lite v0.2.17
    Checking adler32 v1.2.0
    Checking itoa v1.0.18
    Checking dary_heap v0.3.9
    Checking libflate v2.3.0
error[E0658]: `let` expressions in this position are unstable
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libflate-2.3.0/src/finish.rs:128:12
    |
128 |         if let Some(inner) = self.inner.take()
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libflate-2.3.0/src/finish.rs:129:16
    |
129 |             && let Err(e) = inner.complete()
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
```
</details>