### PR TITLE
chore(style): improve error messages [NR-566846]

### DIFF
--- a/opamp-client/src/client.rs
+++ b/opamp-client/src/client.rs
@@ -16,16 +16,16 @@ pub enum ClientError {
     #[error("poison error, a thread panicked while holding a lock")]
     PoisonError,
     /// Error to use when the [`on_connect_failed`](operation::Callbacks::on_connect_failed) callback has been called with this error type, which would consume its value.
-    #[error("connect failed: `{0}`")]
+    #[error("connect failed: {0}")]
     ConnectFailedCallback(String),
     /// Represents a process message error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     ProcessMessageError(#[from] ProcessError),
     /// Represents an HTTP client error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     SenderError(#[from] HttpClientError),
     /// Represents a synchronized state error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     SyncedStateError(#[from] SyncedStateError),
     /// Indicates that the report effective configuration capability is not set.
     #[error("report effective configuration capability is not set")]
@@ -48,7 +48,7 @@ pub enum StartedClientError {
     #[error("error while joining internal thread")]
     JoinError,
     /// Represents a synchronized state error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     ClientError(#[from] ClientError),
 }
 

--- a/opamp-client/src/common/compression.rs
+++ b/opamp-client/src/common/compression.rs
@@ -15,7 +15,7 @@ pub(crate) enum Compressor {
 
 #[derive(Error, Debug, PartialEq)]
 pub enum CompressorError {
-    #[error("encoding format not supported: `{0}`")]
+    #[error("encoding format not supported: {0}")]
     UnsupportedEncoding(String),
 }
 
@@ -36,15 +36,15 @@ impl TryFrom<&[u8]> for Compressor {
 
 #[derive(Error, Debug)]
 pub enum EncoderError {
-    #[error("`{0}`")]
+    #[error("{0}")]
     IO(#[from] io::Error),
 }
 
 #[derive(Error, Debug)]
 pub enum DecoderError {
-    #[error("`{0}`")]
+    #[error("{0}")]
     Prost(#[from] DecodeError),
-    #[error("`{0}`")]
+    #[error("{0}")]
     IO(#[from] io::Error),
 }
 

--- a/opamp-client/src/common/message_processor.rs
+++ b/opamp-client/src/common/message_processor.rs
@@ -27,11 +27,11 @@ use crate::opamp::proto::AgentCapabilities;
 
 #[derive(Error, Debug)]
 pub enum ProcessError {
-    #[error("Error while acquiring read-write lock")]
+    #[error("acquiring read-write lock")]
     PoisonError,
 
     /// Represents a synced state error.
-    #[error("synced state error: `{0}`")]
+    #[error("synced state error: {0}")]
     SyncedStateError(#[from] SyncedStateError),
 }
 

--- a/opamp-client/src/error.rs
+++ b/opamp-client/src/error.rs
@@ -14,7 +14,7 @@ pub enum ConnectionError {
 #[derive(Error, Debug)]
 pub enum NotStartedClientError {
     /// Represents a client error in the OpAMP started client.
-    #[error("`{0}`")]
+    #[error("{0}")]
     ClientError(#[from] crate::client::ClientError),
 }
 

--- a/opamp-client/src/http/http_client.rs
+++ b/opamp-client/src/http/http_client.rs
@@ -7,22 +7,22 @@ use crate::common::compression::{CompressorError, DecoderError, EncoderError};
 #[derive(thiserror::Error, Debug)]
 pub enum HttpClientError {
     /// Represents an http transport crate error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     TransportError(String),
     /// Unsuccessful HTTP response.
-    #[error("Status code: `{0}` Canonical reason: `{1}`")]
+    #[error("status code: '{0}' canonical reason: '{1}'")]
     UnsuccessfulResponse(u16, String),
     /// Represents a decode error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     DecoderError(#[from] DecoderError),
     /// Represents an encode error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     EncoderError(#[from] EncoderError),
     /// Represents a compression error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     CompressionError(#[from] CompressorError),
     /// Represents an http crate consume body error.
-    #[error("`{0}`")]
+    #[error("{0}")]
     HTTPBodyError(String),
 }
 


### PR DESCRIPTION
This PR updates some error messages to make fit the the standard. The changes are minimal:
- Removes backticks
- Assures that error messages are not capitalized

There is still room to improve further: the enums haven't been changed (even if some errors have only one variant) and potentially missing contest haven't been aded.