### PR TITLE
chore(tests): improve http client tests coverage [NR-566846]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1201,7 @@ dependencies = [
  "proto",
  "rand 0.10.1",
  "reqwest",
+ "rstest",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -1299,6 +1306,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1522,6 +1538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1602,35 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -2070,6 +2121,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2637,6 +2718,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ tracing-test = "0.2.6"
 reqwest = "0.13.3"
 assert_matches = "1.5"
 rand = "0.10.1"
+rstest = "0.26.1"
 uuid = { version = "1.23.1", features = ["v7"] }

--- a/opamp-client/Cargo.toml
+++ b/opamp-client/Cargo.toml
@@ -13,6 +13,7 @@ tracing-test.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 assert_matches.workspace = true
 rand.workspace = true
+rstest.workspace = true
 url.workspace = true
 
 [dependencies]

--- a/opamp-client/src/http/client.rs
+++ b/opamp-client/src/http/client.rs
@@ -355,8 +355,10 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use assert_matches::assert_matches;
     use http::StatusCode;
     use mockall::mock;
+    use rstest::rstest;
     use std::collections::HashMap;
     use tracing_test::traced_test;
 
@@ -411,6 +413,24 @@ pub(crate) mod tests {
         }
     }
 
+    /// Concrete `OpAMPHttpClient` configuration used across parametrized tests.
+    type TestClient = OpAMPHttpClient<MockCallbacksMockall, MockHttpClientMockall>;
+    /// A boxed action that exercises one client setter against a configured client.
+    type ClientAction = Box<dyn Fn(&TestClient) -> ClientResult<()>>;
+
+    /// Builds a mock HTTP client whose only expected `post` call is the disconnect
+    /// fired when the `OpAMPHttpClient` is dropped at the end of the test.
+    fn drop_only_http_mock() -> MockHttpClientMockall {
+        let mut mock_client = MockHttpClientMockall::new();
+        mock_client.expect_post().once().returning(|_| {
+            Ok(response_from_server_to_agent(
+                &ServerToAgent::default(),
+                ResponseParts::default(),
+            ))
+        });
+        mock_client
+    }
+
     #[test]
     fn unsuccessful_http_response() {
         let mut mock_client = MockHttpClientMockall::new();
@@ -435,10 +455,10 @@ pub(crate) mod tests {
         )
         .unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             client.send_process().unwrap_err(),
             ClientError::ConnectFailedCallback(_)
-        ));
+        );
     }
 
     #[test]
@@ -456,20 +476,11 @@ pub(crate) mod tests {
             agent_description: agent_description.clone(),
         };
 
-        // Drop fires a disconnect post
-        let mut mock_client = MockHttpClientMockall::new();
-        mock_client.expect_post().once().returning(|_| {
-            Ok(response_from_server_to_agent(
-                &ServerToAgent::default(),
-                ResponseParts::default(),
-            ))
-        });
-
         let (pending_msg, _) = Notifier::new("name".to_string());
         let client = OpAMPHttpClient::new(
             MockCallbacksMockall::new(),
             start_settings,
-            mock_client,
+            drop_only_http_mock(),
             pending_msg,
         )
         .expect("Client creation expects to succeed");
@@ -715,10 +726,7 @@ pub(crate) mod tests {
 
         let result = client.poll();
 
-        assert!(matches!(
-            result.unwrap_err(),
-            ClientError::ConnectFailedCallback(_)
-        ));
+        assert_matches!(result.unwrap_err(), ClientError::ConnectFailedCallback(_));
 
         assert_eq!(
             client.synced_state.remote_config_status().unwrap().unwrap(),
@@ -729,21 +737,13 @@ pub(crate) mod tests {
     #[traced_test]
     #[test]
     fn test_drop_success() {
-        let mut mock_client = MockHttpClientMockall::new();
-        mock_client.expect_post().once().returning(|_| {
-            Ok(response_from_server_to_agent(
-                &ServerToAgent::default(),
-                Default::default(),
-            ))
-        });
-
         let (pending_msg, _) = Notifier::new("msg".to_string());
         let start_settings = StartSettings::default();
         let instance_uid = start_settings.instance_uid.clone();
         let client = OpAMPHttpClient::new(
             MockCallbacksMockall::new(),
             start_settings,
-            mock_client,
+            drop_only_http_mock(),
             pending_msg,
         )
         .unwrap();
@@ -774,5 +774,167 @@ pub(crate) mod tests {
         drop(client);
 
         assert!(logs_contain("some error"));
+    }
+
+    #[rstest]
+    #[case::health(
+        Box::new(|c: &TestClient| c.set_health(ComponentHealth::default())) as ClientAction,
+        Box::new(|e| assert_matches!(e, ClientError::UnsetHealthCapability)),
+    )]
+    #[case::effective_config(
+        Box::new(|c: &TestClient| c.update_effective_config()) as ClientAction,
+        Box::new(|e| assert_matches!(e, ClientError::UnsetEffectConfigCapability)),
+    )]
+    #[case::remote_config_status(
+        Box::new(|c: &TestClient| c.set_remote_config_status(RemoteConfigStatus::default())) as ClientAction,
+        Box::new(|e| assert_matches!(e, ClientError::UnsetRemoteConfigStatusCapability)),
+    )]
+    fn setter_without_capability_returns_error(
+        #[case] action: ClientAction,
+        #[case] assert_expected_error: Box<dyn Fn(ClientError)>,
+    ) {
+        let (pending_msg, _) = Notifier::new("msg".to_string());
+        let client = OpAMPHttpClient::new(
+            MockCallbacksMockall::new(),
+            StartSettings::default(), // capabilities are empty by default
+            drop_only_http_mock(),
+            pending_msg,
+        )
+        .unwrap();
+
+        assert_expected_error(action(&client).unwrap_err());
+    }
+
+    /// Checks that compression works as expected for each setter by setting an attribute twice.
+    /// The first call triggers a message notification while the second, that doesn't change
+    /// the value, doesn't.
+    #[rstest]
+    #[case::agent_description(
+        StartSettings::default(),
+        Box::new(|c: &TestClient| c.set_agent_description(AgentDescription {
+            identifying_attributes: vec![KeyValue {
+                key: "k".to_string(),
+                value: Some(AnyValue {
+                    value: Some(Value::StringValue("v".to_string())),
+                }),
+            }],
+            ..Default::default()
+        })) as ClientAction,
+    )]
+    #[case::health(
+        StartSettings {
+            capabilities: capabilities!(AgentCapabilities::ReportsHealth),
+            ..Default::default()
+        },
+        Box::new(|c: &TestClient| c.set_health(ComponentHealth {
+            healthy: true,
+            ..Default::default()
+        })) as ClientAction,
+    )]
+    #[case::remote_config_status(
+        StartSettings {
+            capabilities: capabilities!(AgentCapabilities::ReportsRemoteConfig),
+            ..Default::default()
+        },
+        Box::new(|c: &TestClient| c.set_remote_config_status(RemoteConfigStatus {
+            status: 2,
+            ..Default::default()
+        })) as ClientAction,
+    )]
+    #[case::custom_capabilities(
+        StartSettings::default(),
+        Box::new(|c: &TestClient| c.set_custom_capabilities(CustomCapabilities {
+            capabilities: vec!["custom.cap".to_string()],
+        })) as ClientAction,
+    )]
+    fn setter_with_unchanged_value_skips_resend_notification(
+        #[case] settings: StartSettings,
+        #[case] action: ClientAction,
+    ) {
+        let (pending_msg, has_pending_msg) = Notifier::new("msg".to_string());
+        let client = OpAMPHttpClient::new(
+            MockCallbacksMockall::new(),
+            settings,
+            drop_only_http_mock(),
+            pending_msg,
+        )
+        .unwrap();
+
+        // First call differs from the default synced state, so it must notify.
+        action(&client).unwrap();
+        has_pending_msg
+            .try_recv()
+            .expect("first call should notify");
+
+        // Second call with the same value should hit the unchanged guard.
+        action(&client).unwrap();
+        assert!(
+            has_pending_msg.try_recv().is_err(),
+            "unchanged value should not notify",
+        );
+    }
+
+    #[test]
+    fn get_agent_description_returns_synced_value() {
+        let agent_description = crate::operation::settings::AgentDescription::testing_non_empty();
+        let settings = StartSettings {
+            agent_description: agent_description.clone(),
+            ..Default::default()
+        };
+        let (pending_msg, _) = Notifier::new("msg".to_string());
+        let client = OpAMPHttpClient::new(
+            MockCallbacksMockall::new(),
+            settings,
+            drop_only_http_mock(),
+            pending_msg,
+        )
+        .unwrap();
+
+        assert_eq!(
+            client.get_agent_description().unwrap(),
+            agent_description.into(),
+        );
+    }
+
+    #[test]
+    fn get_agent_description_default_when_unset() {
+        let (pending_msg, _) = Notifier::new("msg".to_string());
+        let client = OpAMPHttpClient::new(
+            MockCallbacksMockall::new(),
+            StartSettings::default(),
+            drop_only_http_mock(),
+            pending_msg,
+        )
+        .unwrap();
+
+        assert_eq!(
+            client.get_agent_description().unwrap(),
+            AgentDescription::default(),
+        );
+    }
+
+    #[test]
+    fn update_effective_config_callback_error_maps_to_effective_config_error() {
+        use crate::operation::callbacks::tests::CallbacksMockError;
+
+        let mut mock_callbacks = MockCallbacksMockall::new();
+        mock_callbacks
+            .expect_get_effective_config()
+            .once()
+            .returning(|| Err(CallbacksMockError));
+
+        let settings = StartSettings {
+            capabilities: capabilities!(AgentCapabilities::ReportsEffectiveConfig),
+            ..Default::default()
+        };
+        let (pending_msg, _) = Notifier::new("msg".to_string());
+        let client =
+            OpAMPHttpClient::new(mock_callbacks, settings, drop_only_http_mock(), pending_msg)
+                .unwrap();
+
+        assert_matches!(
+            client.update_effective_config().unwrap_err(),
+            ClientError::EffectiveConfigError
+        );
     }
 }


### PR DESCRIPTION
This PR adds unit tests to exercise the coverage gaps in the OpAMPHttpClient implementation. 

It also introduces `rstest` to avail of test-driven test in order to avoid duplication.

There are no production code changes: coverage and test-quality work only.