### PR TITLE
chore: improve opamp client logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit/blob/main/README.md).
 
 ## Unreleased
+### bugfix
+- Decorates client decoder error message
 
 ## v0.0.40 - 2026-06-16
 

--- a/opamp-client/src/http/http_client.rs
+++ b/opamp-client/src/http/http_client.rs
@@ -15,7 +15,9 @@ pub enum HttpClientError {
     /// Represents a decode error.
     #[error("decoding server response: `{source}`. response body: `{body}`")]
     DecoderError {
+        /// Response body captured at decode-failure time.
         body: String,
+        /// Underlying protobuf decode error.
         #[source]
         source: DecoderError,
     },

--- a/opamp-client/src/http/http_client.rs
+++ b/opamp-client/src/http/http_client.rs
@@ -13,8 +13,12 @@ pub enum HttpClientError {
     #[error("status code: '{0}' canonical reason: '{1}'")]
     UnsuccessfulResponse(u16, String),
     /// Represents a decode error.
-    #[error("{0}")]
-    DecoderError(#[from] DecoderError),
+    #[error("decoding server response: `{source}`. response body: `{body}`")]
+    DecoderError {
+        body: String,
+        #[source]
+        source: DecoderError,
+    },
     /// Represents an encode error.
     #[error("{0}")]
     EncoderError(#[from] EncoderError),

--- a/opamp-client/src/http/sender.rs
+++ b/opamp-client/src/http/sender.rs
@@ -6,7 +6,7 @@ use crate::{
     opamp::proto::AgentToServer,
     opamp::proto::ServerToAgent,
 };
-use tracing::instrument;
+use tracing::{error, instrument};
 
 // The HttpSender struct holds the necessary components for sending HTTP messages.
 pub struct HttpSender<C>
@@ -56,7 +56,14 @@ where
             None => Compressor::Plain,
         };
 
-        let response = decode_message::<ServerToAgent>(&compression, response.body())?;
+        let body = response.body();
+        let response = decode_message::<ServerToAgent>(&compression, body).inspect_err(|err| {
+            error!(
+                %err,
+                response_body = %String::from_utf8_lossy(body),
+                "failed to decode ServerToAgent response"
+            )
+        })?;
 
         Ok(response)
     }

--- a/opamp-client/src/http/sender.rs
+++ b/opamp-client/src/http/sender.rs
@@ -6,7 +6,7 @@ use crate::{
     opamp::proto::AgentToServer,
     opamp::proto::ServerToAgent,
 };
-use tracing::{error, instrument};
+use tracing::instrument;
 
 // The HttpSender struct holds the necessary components for sending HTTP messages.
 pub struct HttpSender<C>
@@ -57,12 +57,11 @@ where
         };
 
         let body = response.body();
-        let response = decode_message::<ServerToAgent>(&compression, body).inspect_err(|err| {
-            error!(
-                %err,
-                response_body = %String::from_utf8_lossy(body),
-                "failed to decode ServerToAgent response"
-            )
+        let response = decode_message::<ServerToAgent>(&compression, body).map_err(|source| {
+            HttpClientError::DecoderError {
+                body: String::from_utf8_lossy(body).to_string(),
+                source,
+            }
         })?;
 
         Ok(response)
@@ -82,7 +81,6 @@ mod tests {
     use httpmock::prelude::*;
     use prost::Message;
     use std::collections::HashMap;
-    use tracing_test::traced_test;
     use url::Url;
 
     #[test]
@@ -195,9 +193,10 @@ custom_attributes:
         assert_eq!(res.unwrap(), server_to_agent);
     }
 
-    #[traced_test]
     #[test]
-    fn logs_response_body_when_decode_fails() {
+    fn decode_error_carries_response_body() {
+        // Body that isn't valid protobuf — modeled on the STG-host incident
+        // where the OpAMP server returned an HTML SAML redirect page.
         let invalid_body =
             b"<!DOCTYPE html><html><body><form action=\"https://newrelic.okta.com/app\"></form></body></html>"
                 .to_vec();
@@ -212,11 +211,13 @@ custom_attributes:
 
         let sender = HttpSender::new(mock_client, InstanceUid::create());
         let res = sender.send(AgentToServer::default());
-        assert!(res.is_err());
 
-        // The body must appear in the log so future incidents are diagnosable.
-        assert!(logs_contain("failed to decode ServerToAgent response"));
-        assert!(logs_contain("<!DOCTYPE html>"));
-        assert!(logs_contain("newrelic.okta.com"));
+        match res.unwrap_err() {
+            HttpClientError::DecoderError { body, source: _ } => {
+                assert!(body.contains("<!DOCTYPE html>"));
+                assert!(body.contains("newrelic.okta.com"));
+            }
+            err => panic!("Expected `HttpClientError::DecoderError`, found {err}"),
+        }
     }
 }

--- a/opamp-client/src/http/sender.rs
+++ b/opamp-client/src/http/sender.rs
@@ -82,6 +82,7 @@ mod tests {
     use httpmock::prelude::*;
     use prost::Message;
     use std::collections::HashMap;
+    use tracing_test::traced_test;
     use url::Url;
 
     #[test]
@@ -192,5 +193,30 @@ custom_attributes:
         let res = sender.send(AgentToServer::default());
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), server_to_agent);
+    }
+
+    #[traced_test]
+    #[test]
+    fn logs_response_body_when_decode_fails() {
+        let invalid_body =
+            b"<!DOCTYPE html><html><body><form action=\"https://newrelic.okta.com/app\"></form></body></html>"
+                .to_vec();
+
+        let response = http::Response::builder()
+            .status(StatusCode::OK)
+            .body(invalid_body)
+            .unwrap();
+
+        let mut mock_client = MockHttpClientMockall::new();
+        mock_client.should_post(response);
+
+        let sender = HttpSender::new(mock_client, InstanceUid::create());
+        let res = sender.send(AgentToServer::default());
+        assert!(res.is_err());
+
+        // The body must appear in the log so future incidents are diagnosable.
+        assert!(logs_contain("failed to decode ServerToAgent response"));
+        assert!(logs_contain("<!DOCTYPE html>"));
+        assert!(logs_contain("newrelic.okta.com"));
     }
 }

--- a/opamp-client/src/http/sender.rs
+++ b/opamp-client/src/http/sender.rs
@@ -8,6 +8,12 @@ use crate::{
 };
 use tracing::instrument;
 
+/// Max characters of the response body to retain in [`HttpClientError::DecoderError`]
+/// when decoding fails. Bounds error-message size — the diagnostic goal
+/// (recognising gateway/auth-redirect responses) only needs the first
+/// ~hundred characters.
+const RESPONSE_BODY_LOG_LIMIT: usize = 200;
+
 // The HttpSender struct holds the necessary components for sending HTTP messages.
 pub struct HttpSender<C>
 where
@@ -59,7 +65,10 @@ where
         let body = response.body();
         let response = decode_message::<ServerToAgent>(&compression, body).map_err(|source| {
             HttpClientError::DecoderError {
-                body: String::from_utf8_lossy(body).to_string(),
+                body: String::from_utf8_lossy(body)
+                    .chars()
+                    .take(RESPONSE_BODY_LOG_LIMIT)
+                    .collect(),
                 source,
             }
         })?;
@@ -216,6 +225,30 @@ custom_attributes:
             HttpClientError::DecoderError { body, source: _ } => {
                 assert!(body.contains("<!DOCTYPE html>"));
                 assert!(body.contains("newrelic.okta.com"));
+            }
+            err => panic!("Expected `HttpClientError::DecoderError`, found {err}"),
+        }
+    }
+
+    #[test]
+    fn decode_error_truncates_large_response_body() {
+        // Body longer than the cap — should be truncated to RESPONSE_BODY_LOG_LIMIT chars.
+        let large_body = "X".repeat(300).into_bytes();
+
+        let response = http::Response::builder()
+            .status(StatusCode::OK)
+            .body(large_body)
+            .unwrap();
+
+        let mut mock_client = MockHttpClientMockall::new();
+        mock_client.should_post(response);
+
+        let sender = HttpSender::new(mock_client, InstanceUid::create());
+        let res = sender.send(AgentToServer::default());
+
+        match res.unwrap_err() {
+            HttpClientError::DecoderError { body, source: _ } => {
+                assert_eq!(body.chars().count(), RESPONSE_BODY_LOG_LIMIT);
             }
             err => panic!("Expected `HttpClientError::DecoderError`, found {err}"),
         }


### PR DESCRIPTION
[NR-492836](https://new-relic.atlassian.net/browse/NR-492836)
[Slack Thread](https://newrelic.slack.com/archives/C06LUF770MB/p1764058786079909)
Improve ServerToAgent message logging when client can't decode protobuf

[NR-492836]: https://new-relic.atlassian.net/browse/NR-492836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ