### PR TITLE
fix: adapt notices template to tera v2

### DIFF
--- a/THIRD_PARTY_NOTICES.md.tmpl
+++ b/THIRD_PARTY_NOTICES.md.tmpl
@@ -12,8 +12,8 @@ or by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 For any licenses that require the disclosure of source code, the source code
 can be found at https://github.com/newrelic/opamp-rs.
 {% for dep, licenseObj in dependencies %}
-{%- if dep is containing("opamp-client") %}{% continue %}{% endif %}
-{%- if dep is containing("proto") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="opamp-client") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="proto") %}{% continue %}{% endif %}
 ## {{ dep | split(pat=" ") | first }} <{{ dep | split(pat=" ") | last }}>
 
 Distributed under the following license(s):


### PR DESCRIPTION
## Summary

`rust-licenses-noticer` was upgraded to `tera` v2, which introduced a breaking change to test-argument syntax: test arguments must now be **named** rather than positional.

This updates `THIRD_PARTY_NOTICES.md.tmpl` so the `containing` test passes its pattern as the `pat` kwarg:

```diff
-{%- if dep is containing("opamp-client") %}{% continue %}{% endif %}
-{%- if dep is containing("proto") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="opamp-client") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="proto") %}{% continue %}{% endif %}
```

Without this, notice generation fails with `Found string but expected identifier`.

## Related

Upstream fix: newrelic/rust-licenses-noticer#84