### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

The `security / Rust audit scanner` job fails on `quinn-proto < 0.11.15`:

- **Advisory:** [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) — remote memory exhaustion from unbounded out-of-order stream reassembly
- **Solution:** upgrade to `>= 0.11.15`

This bumps the transitive dependency `quinn-proto` from 0.11.14 to 0.11.15. Lockfile-only change.

## Test plan

- `cargo update -p quinn-proto` (0.11.14 → 0.11.15)
- `cargo check --locked` passes