### PR TITLE
fix: adapt notices template to tera v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: newrelic/rust-licenses-noticer@9d9bb4a5137f7c9d528b4ada1f505866947feccf # v1
+      - uses: newrelic/rust-licenses-noticer@aafd951d814aa31bbe4a5b463fd52ba208905562 # v1.0.4
         with:
           template-file: THIRD_PARTY_NOTICES.md.tmpl
 

--- a/THIRD_PARTY_NOTICES.md.tmpl
+++ b/THIRD_PARTY_NOTICES.md.tmpl
@@ -12,8 +12,8 @@ or by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 For any licenses that require the disclosure of source code, the source code
 can be found at https://github.com/newrelic/opamp-rs.
 {% for dep, licenseObj in dependencies %}
-{%- if dep is containing("opamp-client") %}{% continue %}{% endif %}
-{%- if dep is containing("proto") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="opamp-client") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="proto") %}{% continue %}{% endif %}
 ## {{ dep | split(pat=" ") | first }} <{{ dep | split(pat=" ") | last }}>
 
 Distributed under the following license(s):


### PR DESCRIPTION
tera v2 requires test arguments to be named rather than positional, so `dep is containing("…")` must become `dep is containing(pat="…")`.

See newrelic/rust-licenses-noticer#84 for the upstream fix.